### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import uuid from 'node-uuid'
+import uuid from 'uuid'
 import axiosAdapter from './src/axios-adapter'
 import config from './src/configuration'
 import { isEmpty } from './src/utils'

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
   },
   "dependencies": {
     "axios": "^0.13.1",
-    "node-uuid": "^1.4.7",
     "path-to-regexp": "^1.2.1",
-    "url-parse": "^1.1.1"
+    "url-parse": "^1.1.1",
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "babel-core": "^6.4.0",

--- a/test/rest-store/create-test.js
+++ b/test/rest-store/create-test.js
@@ -63,7 +63,7 @@ describe('create', function () {
     const store = restStore(mappings, storeAdapter)
 
     it('inserts the object into the store before POSTing to the server', function () {
-      const uuid = require('node-uuid')
+      const uuid = require('uuid')
       sinon.collection.stub(uuid, 'v4').returns('123')
       const storeStub = sinon.collection.stub(storeAdapter, 'insert').returns({then () {}})
 

--- a/test/rest-store/update-test.js
+++ b/test/rest-store/update-test.js
@@ -55,7 +55,7 @@ describe('update', function () {
     const store = restStore(mappings, storeAdapter)
 
     it('inserts the object into the store before PUTing to the server', function () {
-      const uuid = require('node-uuid')
+      const uuid = require('uuid')
       sinon.collection.stub(uuid, 'v4').returns('123')
       const storeStub = sinon.collection.stub(storeAdapter, 'update').returns({then () {}})
 


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.